### PR TITLE
🐛 Make build clean command work on fresh repo

### DIFF
--- a/prebuild.js
+++ b/prebuild.js
@@ -3,10 +3,13 @@ const fs = require('fs');
 // directory path
 const dir = 'dist';
 
-// delete directory recursively
-fs.rmdir(dir, { recursive: true }, (err) => {
+const dirExists = fs.existsSync(dir);
+if (dirExists) {
+  // delete directory recursively
+  fs.rm(dir, { recursive: true }, (err) => {
     if (err) {
-        throw err;
+      throw err;
     }
     console.log(`${dir} is deleted`);
-});
+  });
+}


### PR DESCRIPTION
## Summary

Fix first build critical failure

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots
<img width="1066" alt="Screenshot 2023-05-22 at 1 47 57 AM" src="https://github.com/poap-xyz/poap-website/assets/3408480/508d695a-344d-46d1-a79e-b986d1056657">

## Testing

`npm run build` on a fresh install now works! In-addition, the old `rmdir` command is deprecated so you no longer see a warning on successfully builds now.

## Ticket

**[Change!]** Add your issue/ticket (if applies)

## Dependencies

**[Change!]** Let us know if your PR has a dependency with another PR

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I didn't commit unnecessary logs
